### PR TITLE
use version numbers instead of release on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
looks like this isn't enabled yet, see https://travis-ci.org/Tchanders/InformationMeasures.jl to turn it on