### PR TITLE
Add cross-entropy (and Kullback-Leibler divergence?)

### DIFF
--- a/src/Formulae.jl
+++ b/src/Formulae.jl
@@ -124,3 +124,15 @@ end
 function apply_synergy_formula(interaction_information, redundancy)
 	return interaction_information + redundancy
 end
+
+# Parameters:
+#	- probabilities of first variable
+#	- probabilities of second variable
+#	- base of exponent
+function apply_cross_entropy_formula{T<:AbstractFloat, R<:Real}(
+        p_x::AbstractArray{T},
+        p_y::AbstractArray{T},
+        base::R,
+        )
+    return -sum(remove_non_finite.(p_x .* log.(base, p_y)))
+end

--- a/src/Formulae.jl
+++ b/src/Formulae.jl
@@ -11,7 +11,7 @@
 export apply_entropy_formula, apply_conditional_entropy_formula, apply_mutual_information_formula,
 	apply_conditional_mutual_information_formula, apply_interaction_information_formula,
 	apply_total_correlation_formula, apply_specific_information_formula, apply_redundancy_formula,
-	apply_unique_information_formula, apply_synergy_formula
+	apply_unique_information_formula, apply_synergy_formula, apply_cross_entropy_formula
 
 function remove_non_finite(x)
 	return isfinite(x) ? x : zero(x)

--- a/src/Formulae.jl
+++ b/src/Formulae.jl
@@ -129,10 +129,6 @@ end
 #	- probabilities of first variable
 #	- probabilities of second variable
 #	- base of exponent
-function apply_cross_entropy_formula{T<:AbstractFloat, R<:Real}(
-        p_x::AbstractArray{T},
-        p_y::AbstractArray{T},
-        base::R,
-        )
+function apply_cross_entropy_formula{T<:AbstractFloat, R<:Real}(p_x::AbstractArray{T}, p_y::AbstractArray{T}, base::R)
     return -sum(remove_non_finite.(p_x .* log.(base, p_y)))
 end

--- a/src/Measures.jl
+++ b/src/Measures.jl
@@ -11,7 +11,8 @@ export discretize_values,
 	get_total_correlation,
 	get_interaction_information,
 	get_partial_information_decomposition,
-	get_redundancy
+	get_redundancy,
+	cross_entropy,
 
 """
     discretize_values(values_x; <keyword arguments>)
@@ -557,4 +558,56 @@ function get_redundancy(xyz; estimator = "maximum_likelihood", base = 2, probabi
 	else
 		return apply_redundancy_formula(probabilities_xz, probabilities_yz, probabilities_x, probabilities_y, probabilities_z, (1, 2), base)
 	end
+end
+
+
+"""
+    cross_entropy(values_x, values_y; <keyword arguments>)
+Estimate the cross-entropy between two sets of values.
+# Arguments:
+* `values_x`: the first set of data values.
+* `values_y`: the second set of data values.
+* `estimator="maximum_likelihood"`: the entropy estimator.
+* `base=2`: the base of the logarithm, equivalent to the units of information.
+* `mode="uniform_width"`: the discretization algorithm.
+* `number_of_bins=0`: the number of bins (will be overridden if `mode` is `"bayesian_blocks"`).
+* `get_number_of_bins=get_root_n`: the method for calculating the number of bins (only called if `number_of_bins` is `0`).
+* `discretized=false`: whether the data values are already discretized.
+* `lambda=nothing`: the shrinkage instensity, only used if `estimator` is `"shrinkage"`.
+* `prior=1`: the Dirichlet prior, only used if `estimator` is `"dirichlet"`.
+"""
+function cross_entropy(
+        values_x,
+        values_y;
+        estimator="maximum_likelihood",
+        base=2,
+        mode="uniform_width",
+        number_of_bins=0,
+        get_number_of_bins=get_root_n,
+        discretized=false,
+        lambda=nothing,
+        prior=1,
+        )
+    frequency_x, frequency_y = discretized ?
+                               (values_x, values_y) :
+                               discretize_values.((values_x, values_y),
+				        	  mode=mode,
+					          number_of_bins=number_of_bins,
+					          get_number_of_bins=get_number_of_bins,
+					          )
+    
+    probability_x, probability_y = get_probabilities.(estimator,
+				 		      (frequency_x, frequency_y),
+						      lambda=lambda,
+						      prior=prior,
+						      )
+    
+    cross_entropy = apply_cross_entropy_formula(probability_x, probability_y, base)
+    
+    if estimator == "miller_madow"
+        println("WARNING: Miller-Madow correction not implemented for the cross-entropy. ")
+        println("The calculation was performed without applying the correction.")
+    end
+    
+    return cross_entropy
 end

--- a/src/Measures.jl
+++ b/src/Measures.jl
@@ -12,7 +12,7 @@ export discretize_values,
 	get_interaction_information,
 	get_partial_information_decomposition,
 	get_redundancy,
-	cross_entropy,
+	get_cross_entropy
 
 """
     discretize_values(values_x; <keyword arguments>)
@@ -562,7 +562,7 @@ end
 
 
 """
-    cross_entropy(values_x, values_y; <keyword arguments>)
+    get_cross_entropy(values_x, values_y; <keyword arguments>)
 Estimate the cross-entropy between two sets of values.
 # Arguments:
 * `values_x`: the first set of data values.
@@ -573,34 +573,15 @@ Estimate the cross-entropy between two sets of values.
 * `number_of_bins=0`: the number of bins (will be overridden if `mode` is `"bayesian_blocks"`).
 * `get_number_of_bins=get_root_n`: the method for calculating the number of bins (only called if `number_of_bins` is `0`).
 * `discretized=false`: whether the data values are already discretized.
-* `lambda=nothing`: the shrinkage instensity, only used if `estimator` is `"shrinkage"`.
+* `lambda=nothing`: the shrinkage intensity, only used if `estimator` is `"shrinkage"`.
 * `prior=1`: the Dirichlet prior, only used if `estimator` is `"dirichlet"`.
 """
-function cross_entropy(
-        values_x,
-        values_y;
-        estimator="maximum_likelihood",
-        base=2,
-        mode="uniform_width",
-        number_of_bins=0,
-        get_number_of_bins=get_root_n,
-        discretized=false,
-        lambda=nothing,
-        prior=1,
-        )
-    frequency_x, frequency_y = discretized ?
-                               (values_x, values_y) :
-                               discretize_values.((values_x, values_y),
-				        	  mode=mode,
-					          number_of_bins=number_of_bins,
-					          get_number_of_bins=get_number_of_bins,
-					          )
+function get_cross_entropy(values_x, values_y; estimator = "maximum_likelihood", base = 2, mode = "uniform_width", number_of_bins = 0, get_number_of_bins = get_root_n, discretized = false, lambda = nothing, prior = 1)
+    frequency_x = discretized ? values_x : discretize_values(values_x, mode = mode, number_of_bins = number_of_bins, get_number_of_bins = get_number_of_bins)
+    frequency_y = discretized ? values_y : discretize_values(values_y, mode = mode, number_of_bins = number_of_bins, get_number_of_bins = get_number_of_bins)
     
-    probability_x, probability_y = get_probabilities.(estimator,
-				 		      (frequency_x, frequency_y),
-						      lambda=lambda,
-						      prior=prior,
-						      )
+    probability_x = get_probabilities(estimator, frequency_x, lambda = lambda, prior = prior)
+    probability_y = get_probabilities(estimator, frequency_y, lambda = lambda, prior = prior)
     
     cross_entropy = apply_cross_entropy_formula(probability_x, probability_y, base)
     

--- a/test/testCrossEntropy.jl
+++ b/test/testCrossEntropy.jl
@@ -6,15 +6,15 @@ arr41 = rand(10000)
 arr42 = rand(10000)
 
 # The cross-entropy between two copies of an array
-@test cross_entropy(arr41, arr41) \approx log2(100) atol=0.01
+@test_approx_eq_eps cross_entropy(arr41, arr41) log2(100) 0.01
 println("Cross-entropy between array and itself passed.")
 
 # The cross-entropy between an array and itself is equal to the regular entropy of that array
-@test cross_entropy(arr21, arr21) == get_entropy(arr21)
+@test_approx_eq_eps cross_entropy(arr21, arr21) == get_entropy(arr21)
 println("Equality of cross-entropy between array and itself and entropy passed.")
 
 # The cross-entropy between two small samples from the same distribution will be somewhat larger than the regular entropy
-@test cross_entropy(arr21, arr22) \approx log2(10) atol=0.4
+@test_approx_eq_eps cross_entropy(arr21, arr22) log2(10) atol=0.4
 println("Cross-entropy between two small sample arrays passed.")
-@test cross_entropy(arr41, arr42) \approx log2(100) atol=0.02
+@test_approx_eq_eps cross_entropy(arr41, arr42) log2(100) atol=0.02
 println("Cross-entropy between two large sample arrays passed.")

--- a/test/testCrossEntropy.jl
+++ b/test/testCrossEntropy.jl
@@ -7,10 +7,14 @@ arr42 = rand(10000)
 
 # The cross-entropy between two copies of an array
 @test cross_entropy(arr41, arr41) \approx log2(100) atol=0.01
+println("Cross-entropy between array and itself passed.")
 
 # The cross-entropy between an array and itself is equal to the regular entropy of that array
 @test cross_entropy(arr21, arr21) == get_entropy(arr21)
+println("Equality of cross-entropy between array and itself and entropy passed.")
 
 # The cross-entropy between two small samples from the same distribution will be somewhat larger than the regular entropy
 @test cross_entropy(arr21, arr22) \approx log2(10) atol=0.4
+println("Cross-entropy between two small sample arrays passed.")
 @test cross_entropy(arr41, arr42) \approx log2(100) atol=0.02
+println("Cross-entropy between two large sample arrays passed.")

--- a/test/testCrossEntropy.jl
+++ b/test/testCrossEntropy.jl
@@ -1,0 +1,16 @@
+# Tests concerning cross-entropy
+
+arr21 = rand(100)
+arr22 = rand(100)
+arr41 = rand(10000)
+arr42 = rand(10000)
+
+# The cross-entropy between two copies of an array
+@test cross_entropy(arr41, arr41) \approx log2(100) atol=0.01
+
+# The cross-entropy between an array and itself is equal to the regular entropy of that array
+@test cross_entropy(arr21, arr21) == get_entropy(arr21)
+
+# The cross-entropy between two small samples from the same distribution will be somewhat larger than the regular entropy
+@test cross_entropy(arr21, arr22) \approx log2(10) atol=0.4
+@test cross_entropy(arr41, arr42) \approx log2(100) atol=0.02


### PR DESCRIPTION
I would like to use this package to sample the Kullback-Leibler (KL) divergence between two data sets.

The KL divergence can be calculated as the difference of the cross-entropy between the two sets and the entropy of the first one.

In this PR I have added my implementation of calculating the cross-entropy from two sampled data sets.
Eventually, I would like to calculate the KL divergence as well, however a naive implementation such as

`
cross_entropy(values_x, values_y) - get_entropy(values_x)
`

does not handle zeroes correctly, leading to possible negative values of the KL divergence.
This is because `cross_entropy` excludes nonfinite frequencies, whereas this information is not relayed to `get_entropy`.


